### PR TITLE
Adding PyOhio

### DIFF
--- a/README.md
+++ b/README.md
@@ -3517,3 +3517,7 @@ International Telephone Input with Vue https://vue-tel-input.iamstevendao.com/
 The ultimate free and open-source macOS screencapture utility.
 https://isharemac.app
 https://github.com/castdrian/ishare
+
+### PyOhio
+PyOhio is a free, regional Python community conference held in Ohio. We bring together folks from Ohio, the surrounding states, and around the world to meet new people and learn from each other.
+https://www.pyohio.org


### PR DESCRIPTION
Requesting to add the PyOhio conference organisation.

## Your Project
PyOhio, a regional Python conference held in Ohio.

#### 1Password Teams URL
https://pyohio.1password.com

#### Project Name
PyOhio

#### Short Description
A free, regional Python conference held in Ohio.

#### Project Age
We have held this event every year since beginning in 2010.

#### Number Of Core Contributors
3

#### Project Website
https://www.pyohio.org

#### Repository URL(s)
https://github.com/pyohio

#### Latest Release URL(s)

#### License
Our code is primarily MIT, but we don't necessarily have an overall license.

## A Bit About Yourself
I am the Conference Chair for PyOhio 2024. I recently left a job of five years working as an open source community leader and with embedded Python programming.

#### Name
Kattni

#### Email
kattni@pyohio.org

#### Project Role
Conference Chair 2024

#### Profile/Website
https://github.com/kattni

#### Anything else to add?
2024 is our first year back in person since 2020. The same two people ran the conference for the last 6 years due to the obvious circumstances. We recently became a project of the Python Software Foundation, and they suggested following this process to get a 1Password license for our group. 

#### Can we contact you?
We'd love to be in touch to learn how you're using 1Password. Would you be open to our Developer Advocates reaching out?

- [X] Yes, I'm open.
